### PR TITLE
Add a readme and deprecation note for rescheduler

### DIFF
--- a/rescheduler/README.md
+++ b/rescheduler/README.md
@@ -1,0 +1,2 @@
+### Important Note
+Rescheduler has been deprecated and will be removed in subsequent releases. Please make sure that rescheduler is not enabled with priority and preemption in kube-scheduler.


### PR DESCRIPTION
Since we are moving to priorty and preemption, we don't need rescheduler to move pods around to make room for new pods coming in.

/cc @bsalamat 